### PR TITLE
added comment to protect the TESTINSIGHT conditional

### DIFF
--- a/Expert/DUnitX.Expert.CodeGen.Templates.pas
+++ b/Expert/DUnitX.Expert.CodeGen.Templates.pas
@@ -55,6 +55,7 @@ resourcestring
  '{$ENDIF}'#13#10 +
  '  DUnitX.TestFramework;'#13#10 +
  #13#10 +
+ '{ keep comment here to protect the following conditional from being removed by the IDE when adding a unit }'#13#0 +
  '{$IFNDEF TESTINSIGHT}'#13#10 +
  'var'#13#10 +
  '  runner: ITestRunner;'#13#10 +


### PR DESCRIPTION
The IDE (at least that from Delphi 11) remove the $IFNDEF conditional in front of the var section when a unit is added to the test project. As simple comment between the uses section and the conditional prohibits that.